### PR TITLE
Fix redirect after clearing cache

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -49,10 +49,10 @@ class BackendController
                 $permissionClause = $this->getBackendUserAuthentication()->getPagePermsClause(Permission::PAGE_SHOW);
                 $this->dataHandler->start([], []);
 
-                foreach ($pages as $pageUid) {
-                    $pageRow = BackendUtility::readPageAccess($pageUid, $permissionClause);
-                    if ($pageUid !== 0 && $this->getBackendUserAuthentication()->doesUserHaveAccess($pageRow, Permission::PAGE_SHOW)) {
-                        $this->dataHandler->clear_cacheCmd($pageUid);
+                foreach ($pages as $singlePageUid) {
+                    $pageRow = BackendUtility::readPageAccess($singlePageUid, $permissionClause);
+                    if ($singlePageUid !== 0 && $this->getBackendUserAuthentication()->doesUserHaveAccess($pageRow, Permission::PAGE_SHOW)) {
+                        $this->dataHandler->clear_cacheCmd($singlePageUid);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- preserve original page ID when clearing cache so redirect goes back to current page

## Testing
- `php -l Classes/Controller/BackendController.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68446087fb188329b4843f7352f98331